### PR TITLE
Use helpers.exec to run foodcritic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+node_modules
 *.gem
 *.rbc
 /.config

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-## Contributing
+# Contributing
 If you would like to contribute enhancements or fixes, please do the following:
 
 0. Fork the plugin repository.

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -10,14 +10,15 @@ module.exports =
       default: 'foodcritic'
     extraArgs:
       type: 'string'
+      default: ''
 
   activate: ->
     @subscriptions = new CompositeDisposable
     @MessageRegexp = null
-    @subscriptions.add atom.config.observe 'foodcritic.executablePath', (executablePath) =>
-      @executablePath = executablePath
-    @subscriptions.add atom.config.observe 'foodcritic.extraArgs', (extraArgs) =>
-      @extraArgs = extraArgs
+    @subscriptions.add atom.config.observe 'foodcritic.executablePath', =>
+      @executablePath = atom.config.get 'linter-foodcritic.executablePath'
+    @subscriptions.add atom.config.observe 'foodcritic.extraArgs', =>
+      @extraArgs = atom.config.get 'linter-foodcritic.extraArgs'
 
   deactivate: ->
     @subscriptions.dispose()
@@ -46,7 +47,7 @@ module.exports =
         helpers.exec(@executablePath, args, {cwd: cwd}).then (output) ->
           return [] unless output?
           messages = []
-          @MessageRegexp ?= XRegExp regex, ''
+          @MessageRegexp = XRegExp regex, ''
           XRegExp.forEach output, @MessageRegexp, (match, i) ->
             match.line ?= 0
             normFilePath = pathModule.normalize(match.filePath)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -10,70 +10,52 @@ module.exports =
       default: 'foodcritic'
     extraArgs:
       type: 'string'
-      default: ''
 
   activate: ->
     @subscriptions = new CompositeDisposable
     @MessageRegexp = null
-    @subscriptions.add atom.config.observe 'foodcritic.executablePath', =>
-      @executablePath = atom.config.get 'linter-foodcritic.executablePath'
-    @subscriptions.add atom.config.observe 'foodcritic.extraArgs', =>
-      @extraArgs = atom.config.get 'linter-foodcritic.extraArgs'
+    @subscriptions.add atom.config.observe 'foodcritic.executablePath', (executablePath) =>
+      @executablePath = executablePath
+    @subscriptions.add atom.config.observe 'foodcritic.extraArgs', (extraArgs) =>
+      @extraArgs = extraArgs
 
   deactivate: ->
     @subscriptions.dispose()
 
   provideLinter: ->
     provider =
+      name: 'foodcritic'
       grammarScopes: ['source.ruby.chef']
       scope: 'file'
       lintOnFly: false
       lint: (textEditor) =>
-        return new Promise (resolve, reject) =>
-          currentFilePath = textEditor.getPath()
-          fileDir = pathModule.dirname(currentFilePath)
-          cwd = pathModule.dirname(helpers.findFile(fileDir, 'metadata.rb'))
-          if cwd is '.'
-            resolve []
-          currentFileRelPath = pathModule.relative(cwd, currentFilePath)
-          # change filePath to be relative to @cwd
-          filePath = currentFileRelPath.replace(/\\/g, '/').replace(/^\//, '')
-          regex = "(?<text>.+:\\s.+):\\s+(./)?(?<filePath>#{filePath}|[\\w+\\._]+):(?<line>\\d+)"
-          fOutput = ''
-          if @extraArgs
-            args = @extraArgs.split(' ').concat ['.']
-          else
-            args = ['.']
-          process = new BufferedProcess
-            command: @executablePath
-            args: args
-            options:
-              cwd: cwd
-            stdout: (data) ->
-              fOutput += data
-            exit: (code) ->
-              console.log("out: #{fOutput}")
-              return resolve [] unless code is 0
-              return resolve [] unless fOutput?
-              messages = []
-              @MessageRegexp ?= XRegExp regex, ''
-              XRegExp.forEach fOutput, @MessageRegexp, (match, i) ->
-                match.line ?= 0
-                normFilePath = pathModule.normalize(match.filePath)
-                if normFilePath is currentFileRelPath
-                  msg = {
-                    type: 'Error',
-                    text: match.text,
-                    filePath: currentFilePath,
-                    range: helpers.rangeFromLineNumber(textEditor, match.line - 1)
-                  }
-                  messages.push msg if msg.range?
-              , this
-              resolve messages
-
-          process.onWillThrowError ({error, handle}) ->
-            atom.notifications.addError "Failed to run #{@executablePath}",
-              detail: "#{error.message}"
-              dismissable: true
-            handle()
-            resolve []
+        currentFilePath = textEditor.getPath()
+        fileDir = pathModule.dirname(currentFilePath)
+        cwd = pathModule.dirname(helpers.findFile(fileDir, 'metadata.rb'))
+        if cwd is '.'
+          atom.notifications.addWarning('[foodcritic] No metadata.rb found, not linting!', {dismissable: true})
+          return Promise.resolve([])
+        currentFileRelPath = pathModule.relative(cwd, currentFilePath)
+        # change filePath to be relative to @cwd
+        filePath = currentFileRelPath.replace(/\\/g, '/').replace(/^\//, '')
+        regex = "(?<text>.+:\\s.+):\\s+(./)?(?<filePath>#{filePath}|[\\w+\\._]+):(?<line>\\d+)"
+        if @extraArgs
+          args = @extraArgs.split(' ').concat ['.']
+        else
+          args = ['.']
+        helpers.exec(@executablePath, args, {cwd: cwd}).then (output) ->
+          return [] unless output?
+          messages = []
+          @MessageRegexp ?= XRegExp regex, ''
+          XRegExp.forEach output, @MessageRegexp, (match, i) ->
+            match.line ?= 0
+            normFilePath = pathModule.normalize(match.filePath)
+            if normFilePath is currentFileRelPath
+              msg = {
+                type: 'Error',
+                text: match.text,
+                filePath: currentFilePath,
+                range: helpers.rangeFromLineNumber(textEditor, match.line - 1)
+              }
+              messages.push msg if msg.range?
+          messages

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -15,10 +15,10 @@ module.exports =
   activate: ->
     @subscriptions = new CompositeDisposable
     @MessageRegexp = null
-    @subscriptions.add atom.config.observe 'foodcritic.executablePath', =>
-      @executablePath = atom.config.get 'linter-foodcritic.executablePath'
-    @subscriptions.add atom.config.observe 'foodcritic.extraArgs', =>
-      @extraArgs = atom.config.get 'linter-foodcritic.extraArgs'
+    @subscriptions.add atom.config.observe 'linter-foodcritic.executablePath', (executablePath) =>
+      @executablePath = executablePath
+    @subscriptions.add atom.config.observe 'linter-foodcritic.extraArgs', (extraArgs) =>
+      @extraArgs = extraArgs
 
   deactivate: ->
     @subscriptions.dispose()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -46,7 +46,7 @@ module.exports =
           return [] unless output?
           messages = []
           while((match = regex.exec(output)) isnt null)
-            match.line = 1 if not match[2]? or match[2] < 1
+            match.line = 1 if typeof match[2] is 'undefined' or match[2] < 1
             messages.push {
               type: 'Error',
               text: match[1],

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -33,7 +33,7 @@ module.exports =
       lint: (textEditor) =>
         currentFilePath = textEditor.getPath()
         fileDir = pathModule.dirname(currentFilePath)
-        cwd = pathModule.dirname(helpers.findFile(fileDir, 'metadata.rb'))
+        cwd = pathModule.dirname(helpers.find(fileDir, 'metadata.rb'))
         if cwd is '.'
           atom.notifications.addWarning('[foodcritic] No metadata.rb found, not linting!', {dismissable: true})
           return Promise.resolve([])

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -33,7 +33,7 @@ module.exports =
           currentFilePath = textEditor.getPath()
           fileDir = pathModule.dirname(currentFilePath)
           cwd = pathModule.dirname(helpers.findFile(fileDir, 'metadata.rb'))
-          if cwd == '.'
+          if cwd is '.'
             resolve []
           currentFileRelPath = pathModule.relative(cwd, currentFilePath)
           # change filePath to be relative to @cwd
@@ -60,7 +60,7 @@ module.exports =
               XRegExp.forEach fOutput, @MessageRegexp, (match, i) ->
                 match.line ?= 0
                 normFilePath = pathModule.normalize(match.filePath)
-                if normFilePath == currentFileRelPath
+                if normFilePath is currentFileRelPath
                   msg = {
                     type: 'Error',
                     text: match.text,
@@ -71,7 +71,7 @@ module.exports =
               , this
               resolve messages
 
-          process.onWillThrowError ({error,handle}) ->
+          process.onWillThrowError ({error, handle}) ->
             atom.notifications.addError "Failed to run #{@executablePath}",
               detail: "#{error.message}"
               dismissable: true

--- a/package.json
+++ b/package.json
@@ -13,10 +13,48 @@
     "xregexp": "^2.0.0"
   },
   "providedServices": {
-	  "linter": {
-  		"versions": {
-  		  "1.0.0": "provideLinter"
-  		}
-	  }
- }
+    "linter": {
+      "versions": {
+        "1.0.0": "provideLinter"
+      }
+    }
+  },
+  "coffeelintConfig": {
+    "max_line_length": {
+      "value": 120,
+      "level": "warn"
+    },
+    "no_empty_param_list": {
+      "level": "error"
+    },
+    "arrow_spacing": {
+      "level": "error"
+    },
+    "no_interpolation_in_single_quotes": {
+      "level": "error"
+    },
+    "no_debugger": {
+      "level": "error"
+    },
+    "prefer_english_operator": {
+      "level": "error"
+    },
+    "colon_assignment_spacing": {
+      "spacing": {
+        "left": 0,
+        "right": 1
+      },
+      "level": "error"
+    },
+    "braces_spacing": {
+      "spaces": 0,
+      "level": "error"
+    },
+    "spacing_after_comma": {
+      "level": "error"
+    },
+    "no_stand_alone_at": {
+      "level": "error"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "atom-linter": "^3.4.0",
-    "xregexp": "^2.0.0"
+    "atom-linter": "^4.0.0"
   },
   "providedServices": {
     "linter": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "atom-linter": "^3.0.1",
+    "atom-linter": "^3.4.0",
     "xregexp": "^2.0.0"
   },
   "providedServices": {


### PR DESCRIPTION
This PR does a few things:
- Switch to having the helpers module handle execution instead of trying to implement it here.
- Add a warning if no metadata.rb is found instead of silently doing nothing.
- Add coffeelint config
- Add back `node_modules` to the .gitignore file

Fixes #11 (hopefully).
